### PR TITLE
Allow KnockoutComputed interface in knockout-postbox.d.ts

### DIFF
--- a/knockout.postbox/knockout-postbox.d.ts
+++ b/knockout.postbox/knockout-postbox.d.ts
@@ -29,6 +29,14 @@ interface KnockoutObservableArray<T> {
 	syncWith(topic: string, initializeWithLatestValue?: boolean, skipInitialPublish?: boolean, equalityComparer?: (newValue: any /* T */, oldValue: any /* T */) => boolean): KnockoutObservableArray<T>;
 }
 
+interface KnockoutComputed<T> {
+	subscribeTo(topic: string, useLastPublishedValueToInitialize?: boolean, transform?: (val: any) => any /* T */): KnockoutComputed<T>;
+	unsubscribeFrom(topic: string): KnockoutComputed<T>;
+	publishOn(topic: string, skipInitialPublish?: boolean, equalityComparer?: (newValue: any /* T */, oldValue: any /* T */) => boolean): KnockoutComputed<T>;
+	stopPublishingOn(topic: string): KnockoutComputed<T>;
+	syncWith(topic: string, initializeWithLatestValue?: boolean, skipInitialPublish?: boolean, equalityComparer?: (newValue: any /* T */, oldValue: any /* T */) => boolean): KnockoutComputed<T>;
+}
+
 interface KnockoutStatic {
     postbox: KnockoutPostBox;
 }


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

As per the main Postbox github project (https://github.com/rniemeyer/knockout-postbox)
the below quote:
"knockout-postbox augments observables, observableArrays, and computed observables to be able to automatically participate in sending and receiving messages through ko.postbox."
Note that it also allows  "computed observables"
